### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ep_mathjax
+# MathJax Support for Etherpad
 
 ![Publish Status](https://github.com/ether/ep_mathjax/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_mathjax/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_mathjax/actions/workflows/test-and-release.yml)
 


### PR DESCRIPTION
Replace the placeholder `ep_mathjax` heading in README.md with "MathJax Support for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.