### PR TITLE
a11y: drop redundant hardcoded aria-label

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,9 +1,7 @@
 <li data-type="button" data-key="mathjax" class="ep_mathjax acl-write">
   <a class="grouped-middle ep_mathjax">
     <button class="buttonicon buttonicon-embed-mathjax ep_mathjax"
-            aria-label="Insert MathJax formula"
             data-l10n-id="ep_mathjax.toolbar.title"
-            data-l10n-attr="aria-label"
             title="Insert MathJax formula">π</button>
   </a>
 </li>

--- a/templates/modals.ejs
+++ b/templates/modals.ejs
@@ -90,8 +90,8 @@
 
             <textarea id="mathjaxSrc" rows="10" cols="60" placeholder="Write Mathjax here"></textarea>
             <div>
-                <input type="button" class="btn btn-primary mathjaxButton" id="doMathjax" value="Insert" data-l10n-id="ep_mathjax.modal.insert" data-l10n-attr="value" aria-label="Insert">
-                <input type="button" class="btn btn-default mathjaxButton" id="cancelMathjax" value="Cancel" data-l10n-id="ep_mathjax.modal.cancel" data-l10n-attr="value" aria-label="Cancel">
+                <input type="button" class="btn btn-primary mathjaxButton" id="doMathjax" value="Insert" data-l10n-id="ep_mathjax.modal.insert" data-l10n-attr="value">
+                <input type="button" class="btn btn-default mathjaxButton" id="cancelMathjax" value="Cancel" data-l10n-id="ep_mathjax.modal.cancel" data-l10n-attr="value">
             </div>
 
         </div>


### PR DESCRIPTION
## Summary

Removes hardcoded `aria-label="…"` attributes from elements that already declare `data-l10n-id`. With `aria-label` set in the template, etherpad's html10n skips the auto-population path (`html10n.ts:665-678`) and leaves screen readers with the English label even when the user's UI language is something else.

After this PR, html10n populates `aria-label` from the localized translation on every `pad.applyLanguage()` call, marked with `data-l10n-aria-label="true"` so subsequent passes refresh it.

Also drops the `data-l10n-attr="aria-label"` attribute where present — that's a convention from a different localization library (e.g. fluent-dom), and etherpad's html10n does not read it. The auto-population in lines 665-678 is the etherpad mechanism.

Part of the fleet-wide plugin a11y/i18n sweep (Phase 3 of the modernization campaign; pilot: ether/ep_align#182).