### PR TITLE
a11y: flatten interactive nesting (restore localized aria-label)

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,7 +1,6 @@
 <li data-type="button" data-key="mathjax" class="ep_mathjax acl-write">
-  <a class="grouped-middle ep_mathjax">
-    <button class="buttonicon buttonicon-embed-mathjax ep_mathjax"
-            data-l10n-id="ep_mathjax.toolbar.title"
-            title="Insert MathJax formula">π</button>
-  </a>
+  <a class="grouped-middle ep_mathjax buttonicon buttonicon-embed-mathjax"
+     role="button" tabindex="0"
+     data-l10n-id="ep_mathjax.toolbar.title"
+     title="Insert MathJax formula">π</a>
 </li>


### PR DESCRIPTION
## Summary

Flattens nested toolbar markup to a single `<a role="button" tabindex="0">` carrying the icon classes. With no element children (or with a recognized attribute suffix in `data-l10n-id`), etherpad's html10n auto-populates `aria-label` from the localized string per `html10n.ts:665-678`.

**Why this PR exists:** the earlier Phase 3a sweep removed hardcoded `aria-label="…"` on toolbar buttons that have element children (`<span>`/`<button>`) and a `data-l10n-id` without a recognized attribute suffix (`.title`/`.alt`/`.value`/`.placeholder`). For those elements, html10n skips its auto-population path, so they ended up with no accessible name. Flattening the structure makes the auto-population fire.